### PR TITLE
Add display: block to :host, add reference version of default CSS

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -10,6 +10,10 @@
 		/>
 		<title>spring-board-element</title>
 		<style>
+      body {
+        margin: 0 auto;
+        max-width: 600px;
+      }
 			spring-board {
 				--board-background-color: mintcream;
 			}

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,7 +12,6 @@
 		<style>
 			spring-board {
 				--board-background-color: mintcream;
-				display: block;
 			}
 		</style>
 		<script type="module">

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -65,6 +65,6 @@
 				ab589f4dde9fce4180fcf42c7b05185b0a02a5d682e353fa39177995083e0583
 			</option>
 		</select>
-		<spring-board> Nothing here yet! </spring-board>
+		<spring-board></spring-board>
 	</body>
 </html>

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -16,7 +16,6 @@
       }
 			spring-board {
 				--board-background-color: mintcream;
-				display: block;
 			}
 		</style>
 		<script type="module">

--- a/src/default-board.css
+++ b/src/default-board.css
@@ -1,0 +1,26 @@
+/*
+Not used/imported anywhere in the project - just here for reference.
+
+To make an update to the default board CSS - edit this file, copy-paste it
+into the cssnano playground (https://cssnano.co/playground/) to create a
+minified version, then replace what's present in the DEFAULT_BOARD_CSS variable
+in the project's spring-board-element.ts file. Don't forget to commit both files!
+*/
+
+:host {
+	background-color: var(--board-background-color);
+	box-sizing: border-box;
+  display: block;
+	padding: 2rem;
+}
+time {
+	display: none;
+}
+p,
+h1,
+h2,
+h3,
+h4,
+h5 {
+	margin: 0 0 2rem 0;
+}

--- a/src/spring-board-element.ts
+++ b/src/spring-board-element.ts
@@ -3,7 +3,7 @@ import { verify } from '@noble/ed25519';
 
 const encoder = new TextEncoder();
 const DEFAULT_BOARD_CSS =
-	'<style>:host{background-color:var(--board-background-color);box-sizing:border-box;padding:2rem}time{display:none}p,h1,h2,h3,h4,h5{margin:0 0 2rem}</style>';
+	':host{background-color:var(--board-background-color);box-sizing:border-box;display:block;padding:2rem}time{display:none}h1,h2,h3,h4,h5,p{margin:0 0 2rem}';
 
 /**
  * Ensures that all links within a board open in a new tab.
@@ -102,7 +102,7 @@ class SpringBoardElement extends HTMLElement {
 		const verified = await verify(signature, encoder.encode(body), this.key);
 
 		if (verified) {
-			this.shadowRoot!.innerHTML = DEFAULT_BOARD_CSS + body;
+			this.shadowRoot!.innerHTML = `<style>${DEFAULT_BOARD_CSS}</style>` + body;
 		}
 		// TODO: throw an error when invalid? maybe a custom event?
 	}


### PR DESCRIPTION
Fixes #5.

This adds `display: block` to the default `:host` styles for `<spring-board>`. Also added a `default-board.css` file to make it easier to change/update the spec styles later.

Could certainly automate away the manual minify step, but no need to complicate it yet, I think!