### PR TITLE
Inject boards as fragments instead of raw strings

### DIFF
--- a/src/spring-board-element.ts
+++ b/src/spring-board-element.ts
@@ -7,7 +7,7 @@ import { Deferred, openLinksInNewTabs, upgradeProperty } from './utils.js';
 const encoder = new TextEncoder();
 const boardCSS = document.createElement('template');
 boardCSS.innerHTML =
-	':host{background-color:var(--board-background-color);box-sizing:border-box;display:block;padding:2rem}time{display:none}h1,h2,h3,h4,h5,p{margin:0 0 2rem}';
+	'<style>:host{background-color:var(--board-background-color);box-sizing:border-box;display:block;padding:2rem}time{display:none}h1,h2,h3,h4,h5,p{margin:0 0 2rem}</style>';
 
 class SpringBoardElement extends HTMLElement {
 	#loaded = new Deferred<boolean>();

--- a/src/spring-board-element.ts
+++ b/src/spring-board-element.ts
@@ -5,7 +5,8 @@ import { verify } from '@noble/ed25519';
 import { Deferred, openLinksInNewTabs, upgradeProperty } from './utils.js';
 
 const encoder = new TextEncoder();
-const DEFAULT_BOARD_CSS =
+const boardCSS = document.createElement('template');
+boardCSS.innerHTML =
 	':host{background-color:var(--board-background-color);box-sizing:border-box;display:block;padding:2rem}time{display:none}h1,h2,h3,h4,h5,p{margin:0 0 2rem}';
 
 class SpringBoardElement extends HTMLElement {
@@ -41,7 +42,9 @@ class SpringBoardElement extends HTMLElement {
 
 	constructor() {
 		super();
-		this.attachShadow({ mode: 'open' });
+
+		const shadowRoot = this.attachShadow({ mode: 'open' });
+		shadowRoot.appendChild(boardCSS.content.cloneNode(true));
 	}
 
 	connectedCallback() {
@@ -81,7 +84,11 @@ class SpringBoardElement extends HTMLElement {
 		const verified = await verify(signature, encoder.encode(body), this.key);
 
 		if (verified) {
-			this.shadowRoot!.innerHTML = `<style>${DEFAULT_BOARD_CSS}</style>` + body;
+			const template = document.createElement('template');
+			template.innerHTML = body;
+			const content = template.content.cloneNode(true);
+
+			this.shadowRoot!.appendChild(content);
 			this.#loaded.resolve(true);
 		}
 		// TODO: throw an error when invalid? maybe a custom event?


### PR DESCRIPTION
Closes #15.

The branch name is a bit misleading because we _do_ still use `innerHTML`... we're just using it with `template` elements instead. 😅

This is technically a more performant approach (though boards are so simple so that's likely pretty moot) but it does make it easier to eventually query these fragments for a `<time>` element or a `link=next` and could open the door for clients to intercept the board HTML and make modifications before insertion. This should also make it a bit easier to react to pesky nested `<spring-board>` elements per #10.