### PR TITLE
Use vite's nifty inline CSS import instead of copy pasting

### DIFF
--- a/src/default-board.css
+++ b/src/default-board.css
@@ -1,16 +1,15 @@
 /*
-Not used/imported anywhere in the project - just here for reference.
+This is imported into spring-board-element.ts and used to build the template 
+for the default board styles.
 
-To make an update to the default board CSS - edit this file, copy-paste it
-into the cssnano playground (https://cssnano.co/playground/) to create a
-minified version, then replace what's present in the DEFAULT_BOARD_CSS variable
-in the project's spring-board-element.ts file. Don't forget to commit both files!
+Based on the Spring '83 spec's default style expectations:
+https://github.com/robinsloan/spring-83/blob/main/draft-20220629.md#boards-in-the-client
 */
 
 :host {
 	background-color: var(--board-background-color);
 	box-sizing: border-box;
-  display: block;
+	display: block;
 	padding: 2rem;
 }
 time {

--- a/src/spring-board-element.ts
+++ b/src/spring-board-element.ts
@@ -4,10 +4,13 @@ import { verify } from '@noble/ed25519';
 // local
 import { Deferred, openLinksInNewTabs, upgradeProperty } from './utils.js';
 
+// styles
+import css from './default-board.css?inline';
+
+const cssTemplate = document.createElement('template');
+cssTemplate.innerHTML = `<style>${css}</style>`;
+
 const encoder = new TextEncoder();
-const boardCSS = document.createElement('template');
-boardCSS.innerHTML =
-	'<style>:host{background-color:var(--board-background-color);box-sizing:border-box;display:block;padding:2rem}time{display:none}h1,h2,h3,h4,h5,p{margin:0 0 2rem}</style>';
 
 class SpringBoardElement extends HTMLElement {
 	#loaded = new Deferred<boolean>();
@@ -58,7 +61,7 @@ class SpringBoardElement extends HTMLElement {
 		super();
 
 		const shadowRoot = this.attachShadow({ mode: 'open' });
-		shadowRoot.appendChild(boardCSS.content.cloneNode(true));
+		shadowRoot.appendChild(cssTemplate.content.cloneNode(true));
 	}
 
 	connectedCallback() {


### PR DESCRIPTION
I don't think this is a new feature of Vite `3.0.0` — I just forgot it was possible. 😶 